### PR TITLE
Fixes issue #15 (I believe)

### DIFF
--- a/R/enrich.R
+++ b/R/enrich.R
@@ -46,13 +46,15 @@ enrichIt <- function(obj, gene.sets = NULL, groups = 1000, cores = 2) {
         cnts <- obj
     }
     
-    egc <- GeneSetCollection(egc)
-    names <- NULL
+    # egc <- GeneSetCollection(egc) ## maybe it's a version thing, but supplying a matrix with a GeneSet did not work for me
+    # names <- NULL
+    egc <- GSEABase::geneIds(egc) # will return a simple list, which will work if a matrix is supplied to GSVA
     
-    for (x in seq_along(egc)) {
-        setName <- egc[[x]]@setName
-        names <- c(names, setName)
-    }
+    #for (x in seq_along(egc)) {
+    #    setName <- egc[[x]]@setName
+    #    names <- c(names, setName)
+    #} ## this doesn't seem to serve a purpose; otherwise unlist(lapply(egc, function(x) x@setName)) does the job, too
+    ## I wouldn't overwrite the inbuilt names() function, though
     
     cnts <- cnts[rowSums(cnts > 0) != 0, ] 
     # break to groups of cells

--- a/R/enrich.R
+++ b/R/enrich.R
@@ -21,11 +21,15 @@
 #'
 #' 
 #' @examples 
-#' GS <- getGeneSets(library = "H")
+#' # download HALLMARK gene set collection
+#' GS <- getGeneSets(library = "H") 
 #' GS <- GS[[1]] #Reduce list size for example
 #' seurat_ex <- suppressWarnings(Seurat::pbmc_small)
 #' ES <- enrichIt(obj = seurat_ex, gene.sets = GS)
-#'
+#' 
+#' # alternatively, construct your own list of gene sets
+#' myGS <- list(Housekeeping = c("ACTA1", "ACTN1", "GAPDH"),
+#'   Cancer = c("TP53","BRCA2","ERBB2","MYC"))
 #' @export
 #'
 #' @author Nick Borcherding, Jared Andrews

--- a/R/enrich.R
+++ b/R/enrich.R
@@ -7,7 +7,10 @@
 #'
 #' @param obj The count matrix, Seurat, or SingleCellExperiment object.
 #' @param gene.sets Gene sets from \code{\link{getGeneSets}} to use 
-#' for the enrichment analysis.
+#' for the enrichment analysis. Alternatively a simple base R list where
+#' the names of the list elements correspond to the name of the gene set
+#' and the elements themselves are simple vectors of gene names representing
+#' the gene set. 
 #' @param groups The number of cells to separate the enrichment calculation.
 #' @param cores The number of cores to use for parallelization.
 #'
@@ -48,7 +51,9 @@ enrichIt <- function(obj, gene.sets = NULL, groups = 1000, cores = 2) {
     
     # egc <- GeneSetCollection(egc) ## maybe it's a version thing, but supplying a matrix with a GeneSet did not work for me
     # names <- NULL
-    egc <- GSEABase::geneIds(egc) # will return a simple list, which will work if a matrix is supplied to GSVA
+    if( attr(class(egc), "package") == "GSEABase"){
+        egc <- GSEABase::geneIds(egc) # will return a simple list, which will work if a matrix is supplied to GSVA
+    }
     
     #for (x in seq_along(egc)) {
     #    setName <- egc[[x]]@setName

--- a/R/processing.R
+++ b/R/processing.R
@@ -39,10 +39,12 @@ performPCA <- function(enriched, groups) {
 #
 #' @param species The scientific name of the species of interest in 
 #' order to get correcent gene nomenclature
-#' @param library Individual libraries or multiple libraries to select, 
-#' example: library = c("H", "C5").
+#' @param library Individual collection(s) of gene sets, e.g. c("H", "C5").
+#' See \url{https://www.gsea-msigdb.org/gsea/msigdb/collections.jsp} for
+#' all MSigDB collections.
 #' @param gene.sets Select gene sets or pathways, using specific names, 
-#' example: pathways = c("HALLMARK_TNFA_SIGNALING_VIA_NFKB").
+#' example: pathways = c("HALLMARK_TNFA_SIGNALING_VIA_NFKB"). Will only be
+#' honored if library is set, too.
 #'
 #' @examples 
 #' GS <- getGeneSets(library = "H")
@@ -72,11 +74,12 @@ getGeneSets <- function(species = "Homo sapiens",
             tmp2 = msigdbr(species = spec_check, category = library[x])
             m_df <- rbind(m_df, tmp2)
         }
-        
-    }
-    if(!is.null(gene.sets)) {
+      
+        if(!is.null(gene.sets)) {
         m_df <- m_df[m_df$gs_name %in% gene.sets,]
+        }    
     }
+    
     gs <- unique(m_df$gs_name)
     ls <- list()
     for (i in seq_along(gs)) {

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -48,7 +48,8 @@ Individual pathways/gene sets can be isolated from the libraries selected, by se
 If you are using a species other than Homo sapiens, set the `species` parameter to the appropriate scientific name to ensure the gene nomenclature matches your expression data. To check which species are available, use `msigdbr::msigdbr_species()`. 
 
 ```{r}
-GS <- getGeneSets(library = "H")
+## We'll use the HALLMARK gene set collection ("H")
+GS.hallmark <- getGeneSets(library = "H")
 ```
 
 If a user would like to expand beyond the GSEA Molecular Signature Database for pathway analysis, the enrichment function `enrichIt()` uses a list of GeneSet objects from the GSEABase R package. An [excellent vignette](https://www.bioconductor.org/packages/devel/bioc/vignettes/GSEABase/inst/doc/GSEABase.pdf) exists on how to create GeneSet objects to be used in the enrichment analysis.
@@ -60,8 +61,8 @@ The next step is performing the enrichment on the RNA count data. The function `
 *Important Note:* This is computationally intensive and is highly dependent on the number of cells and the number of gene sets included.
 
 ```{r}
-ES.seurat <- enrichIt(obj = pbmc_small, gene.sets = GS, groups = 1000, cores = 2)
-ES.sce <- enrichIt(obj = sce, gene.sets = GS, groups = 1000, cores = 2)
+ES.seurat <- enrichIt(obj = pbmc_small, gene.sets = GS.hallmark, groups = 1000, cores = 2)
+ES.sce <- enrichIt(obj = sce, gene.sets = GS.hallmark, groups = 1000, cores = 2)
 ```
 
 We can then easily add these results back to our Seurat or SCE object.

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -79,7 +79,7 @@ The easiest way to generate almost any visualization for single cell data is via
 
 To keep things consistent, we'll define a pleasing color scheme.
 ```{r}
-colors <- rev(colorRampPalette(c("#FF4B20", "#FFB433", "#C6FDEC", "#7AC5FF", "#0348A6")))
+colors <- colorRampPalette(c("#0348A6", "#7AC5FF", "#C6FDEC", "#FFB433", "#FF4B20"))
 ```
 
 

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -7,9 +7,6 @@ author:
 - name: Jared Andrews
   email: jared.andrews07@gmail.com
   affiliation: Washington University in St. Louis, School of Medicine, St. Louis, MO, USA
-- name: Friederike Dündar
-  email: frd2007@med.cornell.edu
-  affiliation: Weill Cornell Medicine, New York, NY, USA
 date: "February 9, 2021"
 output:
   BiocStyle::html_document:
@@ -42,17 +39,21 @@ sce <- as.SingleCellExperiment(pbmc_small)
 
 # Getting Gene Sets
 
-The first step in the process of performing gene set enrichment analysis is identifying the gene sets we would like to use. The function `getGeneSets()` allows users to isolate a whole or multiple libraries from a list of GSEABase GeneSet objects. We can do this for gene set collections from the built-in [Molecular Signature Database](https://www.gsea-msigdb.org/gsea/msigdb/search.jsp) by setting the parameter `library` equal to the collection(s) of interest.
-For multiple libraries, just set `library = c("Library1", "Library2", etc)`. To check which collections are available, use `msigdbr::msigdbr_collections()`. The `gs_cat` entry indicates the individal gene set collection names (e.g. "C2"). 
-Individual pathways/gene sets can be isolated from the libraries selected, by setting `gene.sets` = the name(s) of the gene sets of interest. For an overview of the gene sets and collections, see <https://www.gsea-msigdb.org/gsea/msigdb/genesets.jsp>.
-If you are using a species other than Homo sapiens, set the `species` parameter to the appropriate scientific name to ensure the gene nomenclature matches your expression data. To check which species are available, use `msigdbr::msigdbr_species()`. 
+The first step in the process of performing gene set enrichment analysis is identifying the gene sets we would like to use. The function `getGeneSets()` allows users to isolate a whole or multiple libraries from a list of `GSEABase` GeneSet objects. We can do this for gene set collections from the built-in [Molecular Signature Database](https://www.gsea-msigdb.org/gsea/msigdb/search.jsp) by setting the parameter `library` equal to the collection(s) of interest.
+For multiple libraries, just set `library = c("C2", "C5")`. 
+To check which collections are available, use `msigdbr::msigdbr_collections()`. 
+The `gs_cat` entry indicates the individal gene set collection names (e.g. "C2"). 
+Individual pathways/gene sets can be isolated from the selected libraries selected, by setting `gene.sets` = the name(s) of the gene sets of interest. For an overview of the gene sets and collections, see <https://www.gsea-msigdb.org/gsea/msigdb/genesets.jsp>.
+If you are using a species other than Homo sapiens, set the `species` parameter to the appropriate scientific name to ensure the gene nomenclature matches your expression data. 
+To check which species are available, use `msigdbr::msigdbr_species()`. 
 
 ```{r}
 ## We'll use the HALLMARK gene set collection ("H")
 GS.hallmark <- getGeneSets(library = "H")
 ```
 
-If a user would like to expand beyond the GSEA Molecular Signature Database for pathway analysis, the enrichment function `enrichIt()` uses a list of GeneSet objects from the GSEABase R package. An [excellent vignette](https://www.bioconductor.org/packages/devel/bioc/vignettes/GSEABase/inst/doc/GSEABase.pdf) exists on how to create GeneSet objects to be used in the enrichment analysis.
+If a user would like to expand beyond the GSEA Molecular Signature Database for pathway analysis, the enrichment function `enrichIt()` can use any list of `GeneSet` objects from the `GSEABase` R package. An [excellent vignette](https://www.bioconductor.org/packages/devel/bioc/vignettes/GSEABase/inst/doc/GSEABase.pdf) exists on how to create GeneSet objects to be used in the enrichment analysis.
+Otherwise, you may also provide a simple named list of gene sets of interest. See `?enrichIt()` for details.
 
 # Enrichment
 

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -7,7 +7,10 @@ author:
 - name: Jared Andrews
   email: jared.andrews07@gmail.com
   affiliation: Washington University in St. Louis, School of Medicine, St. Louis, MO, USA
-date: "August 26th, 2020"
+- name: Friederike Dündar
+  email: frd2007@med.cornell.edu
+  affiliation: Weill Cornell Medicine, New York, NY, USA
+date: "February 9, 2021"
 output:
   BiocStyle::html_document:
     toc_float: true
@@ -25,7 +28,7 @@ library(BiocStyle)
 
 # Loading Processed Single-Cell Data
 
-For the demonstration of *escape*, we will use the example "pbmc_small" data from *Seurat* and also generate a SingleCellExperiment object from it.
+For the demonstration of *escape*, we will use the example "pbmc_small" data from *Seurat* and also generate a `SingleCellExperiment` object from it.
 
 ```{r}
 suppressPackageStartupMessages(library(escape))
@@ -39,7 +42,10 @@ sce <- as.SingleCellExperiment(pbmc_small)
 
 # Getting Gene Sets
 
-The first step in the process of performing gene set enrichment analysis is identifying the gene sets we would like to use. The function `getGeneSets()` allows users to isolate a whole or multiple libraries from a list of GSEABase GeneSet objects. We can do this for gene set collections from the built-in [Molecular Signature Database](https://www.gsea-msigdb.org/gsea/msigdb/search.jsp) by setting the parameter `library` equal to library/libraries of interest. For multiple libraries, just set `library = c("Library1", "Library2", etc)`. Individual pathways/gene sets can be isolated from the libraries selected, by setting `gene.sets` = the name(s) of the gene sets of interest. If you are using a species, other than Homo sapiens, set the `species` parameter to the appropriate scientific name to ensure the gene nomenclature matches your expression data. 
+The first step in the process of performing gene set enrichment analysis is identifying the gene sets we would like to use. The function `getGeneSets()` allows users to isolate a whole or multiple libraries from a list of GSEABase GeneSet objects. We can do this for gene set collections from the built-in [Molecular Signature Database](https://www.gsea-msigdb.org/gsea/msigdb/search.jsp) by setting the parameter `library` equal to the collection(s) of interest.
+For multiple libraries, just set `library = c("Library1", "Library2", etc)`. To check which collections are available, use `msigdbr::msigdbr_collections()`. The `gs_cat` entry indicates the individal gene set collection names (e.g. "C2"). 
+Individual pathways/gene sets can be isolated from the libraries selected, by setting `gene.sets` = the name(s) of the gene sets of interest. For an overview of the gene sets and collections, see <https://www.gsea-msigdb.org/gsea/msigdb/genesets.jsp>.
+If you are using a species other than Homo sapiens, set the `species` parameter to the appropriate scientific name to ensure the gene nomenclature matches your expression data. To check which species are available, use `msigdbr::msigdbr_species()`. 
 
 ```{r}
 GS <- getGeneSets(library = "H")

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -54,14 +54,17 @@ The next step is performing the enrichment on the RNA count data. The function `
 *Important Note:* This is computationally intensive and is highly dependent on the number of cells and the number of gene sets included.
 
 ```{r}
-ES <- enrichIt(obj = pbmc_small, gene.sets = GS, groups = 1000, cores = 2)
+ES.seurat <- enrichIt(obj = pbmc_small, gene.sets = GS, groups = 1000, cores = 2)
 ES.sce <- enrichIt(obj = sce, gene.sets = GS, groups = 1000, cores = 2)
 ```
 
 We can then easily add these results back to our Seurat or SCE object.
 
 ```{r}
-pbmc_small <- AddMetaData(pbmc_small, ES)
+## if working with a Seurat object
+pbmc_small <- Seurat::AddMetaData(pbmc_small, ES.seurat)
+
+## if working with an SCE object
 met.data <- merge(colData(sce), ES.sce, by = "row.names", all=TRUE)
 row.names(met.data) <- met.data$Row.names
 met.data$Row.names <- NULL
@@ -76,7 +79,7 @@ The easiest way to generate almost any visualization for single cell data is via
 
 To keep things consistent, we'll define a pleasing color scheme.
 ```{r}
-colors <- colorRampPalette(c("#FF4B20", "#FFB433", "#C6FDEC", "#7AC5FF", "#0348A6"))
+colors <- rev(colorRampPalette(c("#FF4B20", "#FFB433", "#C6FDEC", "#7AC5FF", "#0348A6")))
 ```
 
 
@@ -85,11 +88,11 @@ colors <- colorRampPalette(c("#FF4B20", "#FFB433", "#C6FDEC", "#7AC5FF", "#0348A
 A simple way to approach visualizations for enrichment results is the heatmap, especially if you are using a number of gene sets or libraries. 
 
 ```{r}
-dittoHeatmap(pbmc_small, genes = NULL, metas = names(ES), 
+dittoHeatmap(pbmc_small, genes = NULL, metas = names(ES.seurat), 
              annot.by = "groups", 
              fontsize = 7, 
              cluster_cols = TRUE,
-             heatmap.colors = rev(colors(50)))
+             heatmap.colors = colors(50))
 ```
 
 A user can also produce a heatmap with select gene sets by providing specific names to the `metas` parameter. For example, we can isolated gene sets involved in apoptosis and DNA damage.
@@ -99,7 +102,7 @@ dittoHeatmap(sce, genes = NULL,
              metas = c("HALLMARK_APOPTOSIS", "HALLMARK_DNA_REPAIR", "HALLMARK_P53_PATHWAY"), 
              annot.by = "groups", 
              fontsize = 7,
-             heatmap.colors = rev(colors(50)))
+             heatmap.colors = colors(50))
 ```
 
 ## Violin Plots
@@ -122,7 +125,7 @@ We can also compare the distribution of enrichment scores of 2 distinct gene set
 dittoScatterHex(sce, x.var = "HALLMARK_DNA_REPAIR", 
                     y.var = "HALLMARK_MTORC1_SIGNALING", 
                     do.contour = TRUE) + 
-        scale_fill_gradientn(colors = rev(colors(11))) 
+        scale_fill_gradientn(colors = colors(11)) 
 ```
 
 We can also separate the graph using the `split.by` parameter, allowing for the direct comparison of categorical variables.
@@ -132,7 +135,7 @@ dittoScatterHex(sce, x.var = "HALLMARK_DNA_REPAIR",
                 y.var = "HALLMARK_MTORC1_SIGNALING", 
                 do.contour = TRUE,
                 split.by = "groups")  + 
-        scale_fill_gradientn(colors = rev(colors(11))) 
+        scale_fill_gradientn(colors = colors(11)) 
 ```
 
 
@@ -143,9 +146,15 @@ Another distribution visualization is using a [Ridge Plot](https://cran.r-projec
 Like above, we can explore the distribution of the **"HALLMARK_DNA_REPAIR"** gene set between groups by calling `ridgeEnrichment()` with the ES2 object. We specify `group = letters.idents`, which will seperate groups on the y-axis. We can also add a rug plot (`add.rug = TRUE`) to look at the discrete sample placement along the enrichment ridge plot. 
 
 ```{r}
+## Seurat object example
 ES2 <- data.frame(pbmc_small[[]], Idents(pbmc_small))
 colnames(ES2)[ncol(ES2)] <- "cluster"
-ridgeEnrichment(ES2, gene.set = "HALLMARK_DNA_REPAIR", group = "letter.idents", add.rug = TRUE)
+
+## SCE object example -- assumes that colData(sce) has a column named "cluster"
+ES2 <- as.data.frame(met.data) # alternatively: as.data.frame(colData(sce))
+
+## plot
+ridgeEnrichment(ES2, gene.set = "HALLMARK_DNA_REPAIR", group = "cluster", add.rug = TRUE)
 ```
 
 In addition to the separation of **letter.idents**, we can also use `ridgeEnrichment()` for better granualarity of multiple variables. For example, instead of looking at the difference just between "Type", we can set `group = "cluster"` and then `facet = "letter.idents"`. This gives a visualization of the enrichment of DNA Repair by cluster and Type.


### PR DESCRIPTION
I modified `enrichIt` so that it uses a simple list of gene sets rather than worrying about GSEA/GSEABase dependencies. This was based on an old error (and its solution) described here: <https://support.bioconductor.org/p/42073/>

This way, users can also easily construct their own customized lists of gene sets without having to go the GeneSetCollection route. 

Also added some details to the vignette to clarify the different handling of Seurat and SCE objects.